### PR TITLE
fix: corrected incorrect naming of the start script file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"bun": ">=1.0.0"
 	},
 	"scripts": {
-		"start": "bun run dist/index.js",
+		"start": "bun run dist/server.js",
 		"dev": "bunx nodemon --exec bun run src/index.ts",
 		"test": "bun test --watch --coverage",
 		"bundle": "bun build --target=bun src/index.ts --outfile dist/server.js --minify",


### PR DESCRIPTION
This pull request includes a change to the `package.json` file to update the script paths for starting and bundling the application.

Updates to script paths:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L9-R9): Changed the `start` script to run `dist/server.js` instead of `dist/index.js`.